### PR TITLE
German

### DIFF
--- a/data/pipanel.ui
+++ b/data/pipanel.ui
@@ -123,7 +123,7 @@
                       <object class="GtkLabel" id="label13">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="label" translatable="yes">Colour</property>
+                        <property name="label" translatable="yes">Color</property>
                         <property name="xalign">0</property>
                       </object>
                       <packing>
@@ -137,7 +137,7 @@
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="receives_default">True</property>
-                        <property name="tooltip_text" translatable="yes">Choose the colour of the desktop background</property>
+                        <property name="tooltip_text" translatable="yes">Choose the color of the desktop background</property>
                         <accessibility>
                           <relation type="labelled-by" target="label13"/>
                         </accessibility>
@@ -163,7 +163,7 @@
                       <object class="GtkLabel" id="label14">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="label" translatable="yes">Text Colour</property>
+                        <property name="label" translatable="yes">Text Color</property>
                         <property name="xalign">0</property>
                       </object>
                       <packing>
@@ -177,7 +177,7 @@
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="receives_default">True</property>
-                        <property name="tooltip_text" translatable="yes">Choose the colour of the text used for desktop icon labels</property>
+                        <property name="tooltip_text" translatable="yes">Choose the color of the text used for desktop icon labels</property>
                         <accessibility>
                           <relation type="labelled-by" target="label14"/>
                         </accessibility>
@@ -382,7 +382,7 @@
                       <object class="GtkLabel" id="label13_">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="label" translatable="yes">Colour</property>
+                        <property name="label" translatable="yes">Color</property>
                         <property name="xalign">0</property>
                       </object>
                       <packing>
@@ -396,7 +396,7 @@
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="receives_default">True</property>
-                        <property name="tooltip_text" translatable="yes">Choose the colour of the desktop background</property>
+                        <property name="tooltip_text" translatable="yes">Choose the color of the desktop background</property>
                         <accessibility>
                           <relation type="labelled-by" target="label13_"/>
                         </accessibility>
@@ -422,7 +422,7 @@
                       <object class="GtkLabel" id="label14_">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="label" translatable="yes">Text Colour</property>
+                        <property name="label" translatable="yes">Text Color</property>
                         <property name="xalign">0</property>
                       </object>
                       <packing>
@@ -436,7 +436,7 @@
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="receives_default">True</property>
-                        <property name="tooltip_text" translatable="yes">Choose the colour of the text used for desktop icon labels</property>
+                        <property name="tooltip_text" translatable="yes">Choose the color of the text used for desktop icon labels</property>
                         <accessibility>
                           <relation type="labelled-by" target="label14_"/>
                         </accessibility>
@@ -696,7 +696,7 @@
                       <object class="GtkLabel" id="label23">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="label" translatable="yes">Colour</property>
+                        <property name="label" translatable="yes">Color</property>
                         <property name="xalign">0</property>
                       </object>
                       <packing>
@@ -710,7 +710,7 @@
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="receives_default">True</property>
-                        <property name="tooltip_text" translatable="yes">Choose the colour of the taskbar background</property>
+                        <property name="tooltip_text" translatable="yes">Choose the color of the taskbar background</property>
                         <accessibility>
                           <relation type="labelled-by" target="label23"/>
                         </accessibility>
@@ -736,7 +736,7 @@
                       <object class="GtkLabel" id="label24">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="label" translatable="yes">Text Colour</property>
+                        <property name="label" translatable="yes">Text Color</property>
                         <property name="xalign">0</property>
                       </object>
                       <packing>
@@ -750,7 +750,7 @@
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="receives_default">True</property>
-                        <property name="tooltip_text" translatable="yes">Choose the colour of text used on the taskbar</property>
+                        <property name="tooltip_text" translatable="yes">Choose the color of text used on the taskbar</property>
                         <accessibility>
                           <relation type="labelled-by" target="label24"/>
                         </accessibility>
@@ -907,7 +907,7 @@
                       <object class="GtkLabel" id="label32">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="label" translatable="yes">Highlight Colour</property>
+                        <property name="label" translatable="yes">Highlight Color</property>
                         <property name="xalign">0</property>
                       </object>
                       <packing>
@@ -921,7 +921,7 @@
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="receives_default">True</property>
-                        <property name="tooltip_text" translatable="yes">Choose the colour used to highlight active elements</property>
+                        <property name="tooltip_text" translatable="yes">Choose the color used to highlight active elements</property>
                         <accessibility>
                           <relation type="labelled-by" target="label32"/>
                         </accessibility>
@@ -947,7 +947,7 @@
                       <object class="GtkLabel" id="label33">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="label" translatable="yes">Highlight Text Colour</property>
+                        <property name="label" translatable="yes">Highlight Text Color</property>
                         <property name="xalign">0</property>
                       </object>
                       <packing>
@@ -961,7 +961,7 @@
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="receives_default">True</property>
-                        <property name="tooltip_text" translatable="yes">Choose the colour used for text on active elements</property>
+                        <property name="tooltip_text" translatable="yes">Choose the color used for text on active elements</property>
                         <accessibility>
                           <relation type="labelled-by" target="label33"/>
                         </accessibility>

--- a/debian/changelog
+++ b/debian/changelog
@@ -316,7 +316,7 @@ pipanel (20161012~175500) jessie; urgency=medium
 
 pipanel (20160719~175800) jessie; urgency=low
 
-  * Updates to highlight colour and desktop picture
+  * Updates to highlight color and desktop picture
 
  -- Simon Long <simon@raspberrypi.org>  Tue, 19 Jul 2016 18:00:00 +0100
 

--- a/po/de.po
+++ b/po/de.po
@@ -28,7 +28,7 @@ msgstr "Schreibtisch"
 
 #: ../src/pipanel.c:2624
 msgid "Restoring configuration - please wait..."
-msgstr "Konfiguration wird wiederhergestellt - bitte warten..."
+msgstr "Konfiguration wiederherstellen - bitte warten..."
 
 #: ../src/pipanel.c:2881
 msgid "Loading configuration - please wait..."
@@ -40,7 +40,7 @@ msgstr "Erscheinungsbild-Einstellungen"
 
 #: ../data/pipanel.ui.h:2
 msgid "Layout"
-msgstr "Layout:"
+msgstr "Layout"
 
 #: ../data/pipanel.ui.h:3
 msgid "Set how the wallpaper should be fitted to the screen"
@@ -72,7 +72,7 @@ msgstr "Bild kacheln"
 
 #: ../data/pipanel.ui.h:10
 msgid "Picture"
-msgstr "Bild:"
+msgstr "Bild"
 
 #: ../data/pipanel.ui.h:11
 msgid "Choose image file to use as wallpaper"
@@ -80,7 +80,7 @@ msgstr "Bilddatei für den Hintergrund auswählen"
 
 #: ../data/pipanel.ui.h:12
 msgid "Color"
-msgstr "Farbe:"
+msgstr "Farbe"
 
 #: ../data/pipanel.ui.h:13
 msgid "Choose the color of the desktop background"
@@ -88,7 +88,7 @@ msgstr "Farbe des Schreibtisch-Hintergrunds auswählen"
 
 #: ../data/pipanel.ui.h:14
 msgid "Text Color"
-msgstr "Textfarbe:"
+msgstr "Textfarbe"
 
 #: ../data/pipanel.ui.h:15
 msgid "Choose the color of the text used for desktop icon labels"
@@ -206,7 +206,7 @@ msgstr "Menüleiste"
 
 #: ../data/pipanel.ui.h:45
 msgid "Font"
-msgstr "Schriftart:"
+msgstr "Schriftart"
 
 #: ../data/pipanel.ui.h:46
 msgid "Choose the font used for labels and menus"
@@ -214,7 +214,7 @@ msgstr "Schriftart für Beschriftungen und Menüs auswählen"
 
 #: ../data/pipanel.ui.h:47
 msgid "Highlight Color"
-msgstr "Hervorhebungsfarbe:"
+msgstr "Hervorhebungsfarbe"
 
 #: ../data/pipanel.ui.h:48
 msgid "Choose the color used to highlight active elements"
@@ -222,7 +222,7 @@ msgstr "Farbe auswählen, um aktive Elemente hervorzuheben"
 
 #: ../data/pipanel.ui.h:49
 msgid "Highlight Text Color"
-msgstr "Hervorhebungstextfarbe:"
+msgstr "Hervorhebungstextfarbe"
 
 #: ../data/pipanel.ui.h:50
 msgid "Choose the color used for text on active elements"
@@ -230,7 +230,7 @@ msgstr "Farbe für Text auf aktiven Elementen auswählen"
 
 #: ../data/pipanel.ui.h:51
 msgid "Mouse Cursor"
-msgstr "Mauszeiger:"
+msgstr "Mauszeiger"
 
 #: ../data/pipanel.ui.h:52
 msgid "Set the size of the mouse cursor"
@@ -286,7 +286,7 @@ msgstr "Standardeinstellungen"
 
 #: ../data/pipanel.ui.h:65
 msgid "_Cancel"
-msgstr "Abbrechen (_C)"
+msgstr "_Abbrechen"
 
 #: ../data/pipanel.ui.h:66
 msgid "_OK"

--- a/po/de.po
+++ b/po/de.po
@@ -2,10 +2,10 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pipanel 0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-28 23:02+0900\n"
-"PO-Revision-Date: 2018-01-10 12:36+0000\n"
-"Last-Translator: Akira Ouchi <akkiesoft@marokun.net>\n"
-"Language-Team: Japanese\n"
+"POT-Creation-Date: 2023-11-18 20:00+0100\n"
+"PO-Revision-Date: 2023-11-18 20:00+0100\n"
+"Last-Translator: Simon Peter <prbono@puredarwin.org>\n"
+"Language-Team: Geran\n"
 "Language: ja\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -15,279 +15,278 @@ msgstr ""
 #: ../src/pipanel.c:2098 ../src/pipanel.c:2803 ../data/pipanel.ui.h:24
 #, c-format
 msgid "Desktop 1"
-msgstr "デスクトップ 1"
+msgstr "Schreibtisch 1"
 
 #: ../src/pipanel.c:2102 ../src/pipanel.c:2804 ../data/pipanel.ui.h:27
 #, c-format
 msgid "Desktop 2"
-msgstr "デスクトップ 2"
+msgstr "Schreibtisch 2"
 
 #: ../src/pipanel.c:2110
 msgid "Desktop"
-msgstr "デスクトップ"
+msgstr "Schreibtisch"
 
 #: ../src/pipanel.c:2624
 msgid "Restoring configuration - please wait..."
-msgstr "構成を復元しています。少々お待ちください。"
+msgstr "Konfiguration wird wiederhergestellt - bitte warten..."
 
 #: ../src/pipanel.c:2881
 msgid "Loading configuration - please wait..."
-msgstr "構成を読み込んでいます。少々お待ちください。"
+msgstr "Konfiguration wird geladen - bitte warten..."
 
 #: ../data/pipanel.ui.h:1 ../data/pipanel.desktop.in.h:1
 msgid "Appearance Settings"
-msgstr "外観の設定"
+msgstr "Erscheinungsbild-Einstellungen"
 
 #: ../data/pipanel.ui.h:2
 msgid "Layout"
-msgstr "レイアウト:"
+msgstr "Layout:"
 
 #: ../data/pipanel.ui.h:3
 msgid "Set how the wallpaper should be fitted to the screen"
-msgstr "壁紙をどのように画面に合わせるか設定します"
+msgstr "Festlegen, wie der Hintergrund auf dem Bildschirm angepasst werden soll"
 
 #: ../data/pipanel.ui.h:4
 msgid "No image"
-msgstr "画像なし"
+msgstr "Kein Bild"
 
 #: ../data/pipanel.ui.h:5
 msgid "Centre image on screen"
-msgstr "画像を画面の中央に配置"
+msgstr "Bild in der Mitte des Bildschirms"
 
 #: ../data/pipanel.ui.h:6
 msgid "Fit image onto screen"
-msgstr "画像を画面に合わせる"
+msgstr "Bild auf Bildschirm anpassen"
 
 #: ../data/pipanel.ui.h:7
 msgid "Fill screen with image"
-msgstr "画像を画面いっぱいに埋める"
+msgstr "Bildschirm mit Bild füllen"
 
 #: ../data/pipanel.ui.h:8
 msgid "Stretch to cover screen"
-msgstr "画面をカバーするように伸ばす"
+msgstr "Strecken, um den Bildschirm zu bedecken"
 
 #: ../data/pipanel.ui.h:9
 msgid "Tile image"
-msgstr "タイル状に並べる"
+msgstr "Bild kacheln"
 
 #: ../data/pipanel.ui.h:10
 msgid "Picture"
-msgstr "画像:"
+msgstr "Bild:"
 
 #: ../data/pipanel.ui.h:11
 msgid "Choose image file to use as wallpaper"
-msgstr "壁紙に使用したい画像を選択します"
+msgstr "Bilddatei für den Hintergrund auswählen"
 
 #: ../data/pipanel.ui.h:12
 msgid "Color"
-msgstr "色:"
+msgstr "Farbe:"
 
 #: ../data/pipanel.ui.h:13
 msgid "Choose the color of the desktop background"
-msgstr "デスクトップの背景色を選択します"
+msgstr "Farbe des Schreibtisch-Hintergrunds auswählen"
 
 #: ../data/pipanel.ui.h:14
 msgid "Text Color"
-msgstr "文字色:"
+msgstr "Textfarbe:"
 
 #: ../data/pipanel.ui.h:15
 msgid "Choose the color of the text used for desktop icon labels"
-msgstr "デスクトップアイコンのラベルに使用する文字の色を選択します"
+msgstr "Farbe des Texts für die Beschriftung der Schreibtisch-Symbole auswählen"
 
 #: ../data/pipanel.ui.h:16
 msgid "Documents"
-msgstr "ドキュメント"
+msgstr "Dokumente"
 
 #: ../data/pipanel.ui.h:17
 msgid "Show the documents folder on the desktop"
-msgstr "ドキュメントフォルダをデスクトップ上に表示します"
+msgstr "Dokumentenordner auf dem Schreibtisch anzeigen"
 
 #: ../data/pipanel.ui.h:18
 msgid "Wastebasket"
-msgstr "ゴミ箱"
+msgstr "Papierkorb"
 
 #: ../data/pipanel.ui.h:19
 msgid "Show the wastebasket on the desktop"
-msgstr "ゴミ箱をデスクトップ上に表示します"
+msgstr "Papierkorb auf dem Schreibtisch anzeigen"
 
 #: ../data/pipanel.ui.h:20
 msgid "Mounted Disks"
-msgstr "マウントされたディスク"
+msgstr "Eingehängte Laufwerke"
 
 #: ../data/pipanel.ui.h:21
 msgid "Show mounted disks on the desktop"
-msgstr "マウントされたディスクをデスクトップ上に表示します"
+msgstr "Eingehängte Laufwerke auf dem Schreibtisch anzeigen"
 
 #: ../data/pipanel.ui.h:22
 msgid "Show identical desktop on second monitor"
-msgstr "セカンドモニターに同じデスクトップを表示"
+msgstr "Identischen Schreibtisch auf dem zweiten Monitor anzeigen"
 
 #: ../data/pipanel.ui.h:23
 msgid ""
 "Check this box to show the same desktop image and icons on both monitors"
 msgstr ""
-"ボックスにチェックすると、両方のモニターに同じデスクトップ画像とアイコンを表"
-"示します"
+"Dieses Kästchen aktivieren, um das gleiche Schreibtisch-Bild und die gleichen Symbole auf beiden Monitoren anzuzeigen"
 
 #: ../data/pipanel.ui.h:25
 msgid "Desktop Folder"
-msgstr "デスクトップフォルダー"
+msgstr "Desktop-Ordner"
 
 #: ../data/pipanel.ui.h:26
 msgid "Choose the folder containing files to be shown on the second desktop"
-msgstr "セカンドデスクトップに表示するファイルが含まれるフォルダーを選択します"
+msgstr "Ordner auswählen, der die Dateien für den zweiten Schreibtisch enthält"
 
 #: ../data/pipanel.ui.h:28
 msgid "Size"
-msgstr "サイズ:"
+msgstr "Größe:"
 
 #: ../data/pipanel.ui.h:29
 msgid "Set the size of icons used on the toolbar and menu"
-msgstr "ツールバーとメニューで使用されるアイコンのサイズを設定します"
+msgstr "Größe der Symbole auf der Symbolleiste und im Menü festlegen"
 
 #: ../data/pipanel.ui.h:30
 msgid "Very large (48x48)"
-msgstr "特大 (48x48)"
+msgstr "Sehr groß (48x48)"
 
 #: ../data/pipanel.ui.h:31
 msgid "Large (32x32)"
-msgstr "大 (32x32)"
+msgstr "Groß (32x32)"
 
 #: ../data/pipanel.ui.h:32
 msgid "Medium (24x24)"
-msgstr "中 (24x24)"
+msgstr "Mittel (24x24)"
 
 #: ../data/pipanel.ui.h:33
 msgid "Small (16x16)"
-msgstr "小 (16x16)"
+msgstr "Klein (16x16)"
 
 #: ../data/pipanel.ui.h:34
 msgid "Position"
-msgstr "位置:"
+msgstr "Position:"
 
 #: ../data/pipanel.ui.h:35
 msgid "Top"
-msgstr "上"
+msgstr "Oben"
 
 #: ../data/pipanel.ui.h:36
 msgid "Show the taskbar at the top of the screen"
-msgstr "タスクバーを画面の上部に表示します"
+msgstr "Taskleiste oben auf dem Bildschirm anzeigen"
 
 #: ../data/pipanel.ui.h:37
 msgid "Bottom"
-msgstr "下"
+msgstr "Unten"
 
 #: ../data/pipanel.ui.h:38
 msgid "Show the taskbar at the bottom of the screen"
-msgstr "タスクバーを画面の下部に表示します"
+msgstr "Taskleiste unten auf dem Bildschirm anzeigen"
 
 #: ../data/pipanel.ui.h:39
 msgid "Choose the color of the taskbar background"
-msgstr "タスクバーの背景色を選択します"
+msgstr "Farbe des Hintergrunds der Taskleiste auswählen"
 
 #: ../data/pipanel.ui.h:40
 msgid "Choose the color of text used on the taskbar"
-msgstr "タスクバーの文字色を選択します"
+msgstr "Farbe des Texts für die Taskleiste auswählen"
 
 #: ../data/pipanel.ui.h:41
 msgid "Location"
-msgstr "位置:"
+msgstr "Ort:"
 
 #: ../data/pipanel.ui.h:42
 msgid "Show the taskbar on screen 1"
-msgstr "タスクバーをモニター1に表示"
+msgstr "Taskleiste auf Bildschirm 1 anzeigen"
 
 #: ../data/pipanel.ui.h:43
 msgid "Show the taskbar on screen 2"
-msgstr "タスクバーをモニター2に表示"
+msgstr "Taskleiste auf Bildschirm 2 anzeigen"
 
 #: ../data/pipanel.ui.h:44
 msgid "Menu Bar"
-msgstr "タスクバー"
+msgstr "Menüleiste"
 
 #: ../data/pipanel.ui.h:45
 msgid "Font"
-msgstr "フォント:"
+msgstr "Schriftart:"
 
 #: ../data/pipanel.ui.h:46
 msgid "Choose the font used for labels and menus"
-msgstr "ラベルやメニューで使用するフォントを選択します"
+msgstr "Schriftart für Beschriftungen und Menüs auswählen"
 
 #: ../data/pipanel.ui.h:47
 msgid "Highlight Color"
-msgstr "ハイライト色:"
+msgstr "Hervorhebungsfarbe:"
 
 #: ../data/pipanel.ui.h:48
 msgid "Choose the color used to highlight active elements"
-msgstr "アクティブな要素をハイライトするときに使用する色を選択します"
+msgstr "Farbe auswählen, um aktive Elemente hervorzuheben"
 
 #: ../data/pipanel.ui.h:49
 msgid "Highlight Text Color"
-msgstr "ハイライト文字色:"
+msgstr "Hervorhebungstextfarbe:"
 
 #: ../data/pipanel.ui.h:50
 msgid "Choose the color used for text on active elements"
-msgstr "アクティブな要素をハイライトするときに使用する文字の色を選択します"
+msgstr "Farbe für Text auf aktiven Elementen auswählen"
 
 #: ../data/pipanel.ui.h:51
 msgid "Mouse Cursor"
-msgstr "マウスカーソル:"
+msgstr "Mauszeiger:"
 
 #: ../data/pipanel.ui.h:52
 msgid "Set the size of the mouse cursor"
-msgstr "マウスカーソルの大きさを設定します"
+msgstr "Größe des Mauszeigers festlegen"
 
 #: ../data/pipanel.ui.h:53
 msgid "Large"
-msgstr "大"
+msgstr "Groß"
 
 #: ../data/pipanel.ui.h:54
 msgid "Medium"
-msgstr "中"
+msgstr "Mittel"
 
 #: ../data/pipanel.ui.h:55
 msgid "Small"
-msgstr "小"
+msgstr "Klein"
 
 #: ../data/pipanel.ui.h:56
 msgid "System"
-msgstr "システム"
+msgstr "System"
 
 #: ../data/pipanel.ui.h:57
 msgid "For large screens:"
-msgstr "大きな画面向け:"
+msgstr "Für große Bildschirme:"
 
 #: ../data/pipanel.ui.h:58
 msgid "Set Defaults"
-msgstr "デフォルト設定にする"
+msgstr "Standardeinstellungen festlegen"
 
 #: ../data/pipanel.ui.h:59
 msgid "Set to default values for high-resolution displays"
-msgstr "高解像度の画面向けのデフォルト値に設定します"
+msgstr "Auf Standardwerte für hochauflösende Displays setzen"
 
 #: ../data/pipanel.ui.h:60
 msgid "For medium screens:"
-msgstr "普通の画面向け:"
+msgstr "Für mittelgroße Bildschirme:"
 
 #: ../data/pipanel.ui.h:61
 msgid "Set to default values for medium-resolution displays"
-msgstr "中解像度の画面向けのデフォルト値に設定します"
+msgstr "Auf Standardwerte für mittlere Auflösung setzen"
 
 #: ../data/pipanel.ui.h:62
 msgid "For small screens:"
-msgstr "小さな画面向け:"
+msgstr "Für kleine Bildschirme:"
 
 #: ../data/pipanel.ui.h:63
 msgid "Set to default values for low-resolution displays"
-msgstr "低解像度の画面向けのデフォルト値に設定します"
+msgstr "Auf Standardwerte für niedrige Auflösung setzen"
 
 #: ../data/pipanel.ui.h:64
 msgid "Defaults"
-msgstr "デフォルト"
+msgstr "Standardeinstellungen"
 
 #: ../data/pipanel.ui.h:65
 msgid "_Cancel"
-msgstr "キャンセル(_C)"
+msgstr "Abbrechen (_C)"
 
 #: ../data/pipanel.ui.h:66
 msgid "_OK"
@@ -295,18 +294,18 @@ msgstr "_OK"
 
 #: ../data/pipanel.desktop.in.h:2
 msgid "Configure the appearance of the desktop and windows"
-msgstr "デスクトップやウィンドウの外観を設定します"
+msgstr "Erscheinungsbild von Schreibtisch und Fenstern konfigurieren"
 
 #, c-format
 #~ msgid ""
 #~ "Desktop\n"
 #~ "%s"
 #~ msgstr ""
-#~ "デスクトップ\n"
+#~ "Schreibtisch\n"
 #~ "%s"
 
 #~ msgid "New mouse cursor size will take effect at reboot"
-#~ msgstr "新しいマウスカーソルの設定は再起動後に適用されます"
+#~ msgstr "Die neue Mauszeigergröße wird nach dem Neustart wirksam"
 
 #~ msgid "Password Required"
-#~ msgstr "パスワードが必要です"
+#~ msgstr "Passwort erforderlich"

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -75,19 +75,19 @@ msgid "Choose image file to use as wallpaper"
 msgstr "Choose image file to use as wallpaper"
 
 #: ../data/pipanel.ui.h:12
-msgid "Colour"
+msgid "Color"
 msgstr "Colour:"
 
 #: ../data/pipanel.ui.h:13
-msgid "Choose the colour of the desktop background"
-msgstr "Choose the colour of the desktop background"
+msgid "Choose the color of the desktop background"
+msgstr "Choose the color of the desktop background"
 
 #: ../data/pipanel.ui.h:14
-msgid "Text Colour"
+msgid "Text Color"
 msgstr "Text Colour:"
 
 #: ../data/pipanel.ui.h:15
-msgid "Choose the colour of the text used for desktop icon labels"
+msgid "Choose the color of the text used for desktop icon labels"
 msgstr "Choose the colour of the text used for desktop icon labels"
 
 #: ../data/pipanel.ui.h:16
@@ -185,11 +185,11 @@ msgid "Show the taskbar at the bottom of the screen"
 msgstr "Show the taskbar at the bottom of the screen"
 
 #: ../data/pipanel.ui.h:39
-msgid "Choose the colour of the taskbar background"
+msgid "Choose the color of the taskbar background"
 msgstr "Choose the colour of the taskbar background"
 
 #: ../data/pipanel.ui.h:40
-msgid "Choose the colour of text used on the taskbar"
+msgid "Choose the color of text used on the taskbar"
 msgstr "Choose the colour of text used on the taskbar"
 
 #: ../data/pipanel.ui.h:41
@@ -217,19 +217,19 @@ msgid "Choose the font used for labels and menus"
 msgstr "Choose the font used for labels and menus"
 
 #: ../data/pipanel.ui.h:47
-msgid "Highlight Colour"
+msgid "Highlight Color"
 msgstr "Highlight Colour:"
 
 #: ../data/pipanel.ui.h:48
-msgid "Choose the colour used to highlight active elements"
+msgid "Choose the color used to highlight active elements"
 msgstr "Choose the colour used to highlight active elements"
 
 #: ../data/pipanel.ui.h:49
-msgid "Highlight Text Colour"
+msgid "Highlight Text Color"
 msgstr "Highlight Text Colour:"
 
 #: ../data/pipanel.ui.h:50
-msgid "Choose the colour used for text on active elements"
+msgid "Choose the color used for text on active elements"
 msgstr "Choose the colour used for text on active elements"
 
 #: ../data/pipanel.ui.h:51

--- a/po/hy.po
+++ b/po/hy.po
@@ -75,19 +75,19 @@ msgid "Choose image file to use as wallpaper"
 msgstr "Ընտրել նկարը էկրանի համար"
 
 #: ../data/pipanel.ui.h:12
-msgid "Colour"
+msgid "Color"
 msgstr "Գույն՝"
 
 #: ../data/pipanel.ui.h:13
-msgid "Choose the colour of the desktop background"
+msgid "Choose the color of the desktop background"
 msgstr "Ընտրել գույնը աշխատասեղանի ֆոնի համար"
 
 #: ../data/pipanel.ui.h:14
-msgid "Text Colour"
+msgid "Text Color"
 msgstr "Տեքստի գույնը:"
 
 #: ../data/pipanel.ui.h:15
-msgid "Choose the colour of the text used for desktop icon labels"
+msgid "Choose the color of the text used for desktop icon labels"
 msgstr "Ընտրել տեքստի գույնը աշխատասեղանի պատկերի պիտակների համար"
 
 #: ../data/pipanel.ui.h:16
@@ -185,11 +185,11 @@ msgid "Show the taskbar at the bottom of the screen"
 msgstr "Ցույց տալ խնդրագոտին էկրանի ներքևում"
 
 #: ../data/pipanel.ui.h:39
-msgid "Choose the colour of the taskbar background"
+msgid "Choose the color of the taskbar background"
 msgstr "Ընտրել խնդրագոտու ֆոնի գույնը"
 
 #: ../data/pipanel.ui.h:40
-msgid "Choose the colour of text used on the taskbar"
+msgid "Choose the color of text used on the taskbar"
 msgstr "ԸՆտրել խնդրագոտում օգտագործված տեքստի գույնը"
 
 #: ../data/pipanel.ui.h:41
@@ -217,19 +217,19 @@ msgid "Choose the font used for labels and menus"
 msgstr "Choose the font used for labels and menus"
 
 #: ../data/pipanel.ui.h:47
-msgid "Highlight Colour"
+msgid "Highlight Color"
 msgstr "Ընդգծել գույնը՝"
 
 #: ../data/pipanel.ui.h:48
-msgid "Choose the colour used to highlight active elements"
+msgid "Choose the color used to highlight active elements"
 msgstr "Ընտրել ակտիվ տարրերում ընդգծվող գույնը"
 
 #: ../data/pipanel.ui.h:49
-msgid "Highlight Text Colour"
+msgid "Highlight Text Color"
 msgstr "Ընդգծել տեքստի գույնը՝"
 
 #: ../data/pipanel.ui.h:50
-msgid "Choose the colour used for text on active elements"
+msgid "Choose the color used for text on active elements"
 msgstr "Ընտրել ակտիվ տարրերում ընդգծվող տեքստի գույնը"
 
 #: ../data/pipanel.ui.h:51

--- a/po/is.po
+++ b/po/is.po
@@ -76,19 +76,19 @@ msgid "Choose image file to use as wallpaper"
 msgstr "Veldu myndskrá til að nota sem bakgrunnsmynd"
 
 #: ../data/pipanel.ui.h:12
-msgid "Colour"
+msgid "Color"
 msgstr "Litur"
 
 #: ../data/pipanel.ui.h:13
-msgid "Choose the colour of the desktop background"
+msgid "Choose the color of the desktop background"
 msgstr "Veldu hér lit bakgrunns skjáborðsins"
 
 #: ../data/pipanel.ui.h:14
-msgid "Text Colour"
+msgid "Text Color"
 msgstr "Litur texta"
 
 #: ../data/pipanel.ui.h:15
-msgid "Choose the colour of the text used for desktop icon labels"
+msgid "Choose the color of the text used for desktop icon labels"
 msgstr ""
 "Veldu hér litinn sem notaður er á texta í merkingum táknmynda á skjáborði"
 
@@ -187,11 +187,11 @@ msgid "Show the taskbar at the bottom of the screen"
 msgstr "Birta verkefnastiku neðst á skjánum"
 
 #: ../data/pipanel.ui.h:39
-msgid "Choose the colour of the taskbar background"
+msgid "Choose the color of the taskbar background"
 msgstr "Veldu hér bakgrunnslit verkefnastiku"
 
 #: ../data/pipanel.ui.h:40
-msgid "Choose the colour of text used on the taskbar"
+msgid "Choose the color of text used on the taskbar"
 msgstr "Veldu hér textalit verkefnastiku"
 
 #: ../data/pipanel.ui.h:41
@@ -219,19 +219,19 @@ msgid "Choose the font used for labels and menus"
 msgstr "Veldu letur fyrir merkingar og valmyndir"
 
 #: ../data/pipanel.ui.h:47
-msgid "Highlight Colour"
+msgid "Highlight Color"
 msgstr "Áherslulitur"
 
 #: ../data/pipanel.ui.h:48
-msgid "Choose the colour used to highlight active elements"
+msgid "Choose the color used to highlight active elements"
 msgstr "Veldu hér litinn sem notaður er til að áherslulita virk atriði"
 
 #: ../data/pipanel.ui.h:49
-msgid "Highlight Text Colour"
+msgid "Highlight Text Color"
 msgstr "Áherslulitur texta"
 
 #: ../data/pipanel.ui.h:50
-msgid "Choose the colour used for text on active elements"
+msgid "Choose the color used for text on active elements"
 msgstr "Veldu hér litinn sem notaður er á texta í virkum atriðum"
 
 #: ../data/pipanel.ui.h:51

--- a/po/it.po
+++ b/po/it.po
@@ -80,20 +80,20 @@ msgstr "Seleziona l'immagine da utilizzare come sfondo"
 
 # ends with ":"
 #: ../data/pipanel.ui.h:12
-msgid "Colour"
+msgid "Color"
 msgstr "Colore:"
 
 #: ../data/pipanel.ui.h:13
-msgid "Choose the colour of the desktop background"
+msgid "Choose the color of the desktop background"
 msgstr "Seleziona il colore di sfondo della scrivania"
 
 # ends with ":"
 #: ../data/pipanel.ui.h:14
-msgid "Text Colour"
+msgid "Text Color"
 msgstr "Colore del testo:"
 
 #: ../data/pipanel.ui.h:15
-msgid "Choose the colour of the text used for desktop icon labels"
+msgid "Choose the color of the text used for desktop icon labels"
 msgstr "Seleziona il colore del testo utilizzato per le etichette delle icone sulla scrivania"
 
 #: ../data/pipanel.ui.h:16
@@ -192,11 +192,11 @@ msgid "Show the taskbar at the bottom of the screen"
 msgstr "Mostra la barra delle attività nel bordo inferiore dello schermo"
 
 #: ../data/pipanel.ui.h:39
-msgid "Choose the colour of the taskbar background"
+msgid "Choose the color of the taskbar background"
 msgstr "Seleziona il colore di sfondo della barra delle attività"
 
 #: ../data/pipanel.ui.h:40
-msgid "Choose the colour of text used on the taskbar"
+msgid "Choose the color of text used on the taskbar"
 msgstr "Sceglie il colore del testo usato nella barra delle attività"
 
 # ends with ":"
@@ -227,20 +227,20 @@ msgstr "Seleziona il carattere utilizzato per etichette e menu"
 
 # ends with ":"
 #: ../data/pipanel.ui.h:47
-msgid "Highlight Colour"
+msgid "Highlight Color"
 msgstr "Colore in evidenza:"
 
 #: ../data/pipanel.ui.h:48
-msgid "Choose the colour used to highlight active elements"
+msgid "Choose the color used to highlight active elements"
 msgstr "Seleziona il colore utilizzato per evidenziare gli elementi attivi"
 
 # ends with ":"
 #: ../data/pipanel.ui.h:49
-msgid "Highlight Text Colour"
+msgid "Highlight Text Color"
 msgstr "Colore del testo in evidenza:"
 
 #: ../data/pipanel.ui.h:50
-msgid "Choose the colour used for text on active elements"
+msgid "Choose the color used for text on active elements"
 msgstr "Seleziona il colore utilizzato per il testo degli elementi attivi"
 
 # ends with ":"

--- a/po/ko.po
+++ b/po/ko.po
@@ -76,19 +76,19 @@ msgid "Choose image file to use as wallpaper"
 msgstr "바탕화면으로 사용할 그림 파일 선택"
 
 #: ../data/pipanel.ui.h:12
-msgid "Colour"
+msgid "Color"
 msgstr "색상"
 
 #: ../data/pipanel.ui.h:13
-msgid "Choose the colour of the desktop background"
+msgid "Choose the color of the desktop background"
 msgstr "데스크톱 배경색 선택"
 
 #: ../data/pipanel.ui.h:14
-msgid "Text Colour"
+msgid "Text Color"
 msgstr "글자 색상"
 
 #: ../data/pipanel.ui.h:15
-msgid "Choose the colour of the text used for desktop icon labels"
+msgid "Choose the color of the text used for desktop icon labels"
 msgstr "데스크톱 아이콘 라벨 글자 색상 선택"
 
 #: ../data/pipanel.ui.h:16
@@ -184,11 +184,11 @@ msgid "Show the taskbar at the bottom of the screen"
 msgstr "화면 사단에 작업 표시줄 표시"
 
 #: ../data/pipanel.ui.h:39
-msgid "Choose the colour of the taskbar background"
+msgid "Choose the color of the taskbar background"
 msgstr "작업 표시줄 배경색 선택"
 
 #: ../data/pipanel.ui.h:40
-msgid "Choose the colour of text used on the taskbar"
+msgid "Choose the color of text used on the taskbar"
 msgstr "작업 표시줄 글자 색상 선택"
 
 #: ../data/pipanel.ui.h:41
@@ -216,19 +216,19 @@ msgid "Choose the font used for labels and menus"
 msgstr "메뉴와 라벨에 사용되는 글꼴 선택"
 
 #: ../data/pipanel.ui.h:47
-msgid "Highlight Colour"
+msgid "Highlight Color"
 msgstr "강조 색상"
 
 #: ../data/pipanel.ui.h:48
-msgid "Choose the colour used to highlight active elements"
+msgid "Choose the color used to highlight active elements"
 msgstr "활성 요소를 강조할 때 사용되는 색상 선택"
 
 #: ../data/pipanel.ui.h:49
-msgid "Highlight Text Colour"
+msgid "Highlight Text Color"
 msgstr "강조된 글자 색상"
 
 #: ../data/pipanel.ui.h:50
-msgid "Choose the colour used for text on active elements"
+msgid "Choose the color used for text on active elements"
 msgstr "활성 요소의 글자 색상 선택"
 
 #: ../data/pipanel.ui.h:51

--- a/po/nb.po
+++ b/po/nb.po
@@ -76,19 +76,19 @@ msgid "Choose image file to use as wallpaper"
 msgstr "Velg en billedfil å bruke som skrivebordsbakgrunn"
 
 #: ../data/pipanel.ui.h:12
-msgid "Colour"
+msgid "Color"
 msgstr "Farge"
 
 #: ../data/pipanel.ui.h:13
-msgid "Choose the colour of the desktop background"
+msgid "Choose the color of the desktop background"
 msgstr "Velg fargen til skrivebordsbakgrunnen"
 
 #: ../data/pipanel.ui.h:14
-msgid "Text Colour"
+msgid "Text Color"
 msgstr "Tekstfarge"
 
 #: ../data/pipanel.ui.h:15
-msgid "Choose the colour of the text used for desktop icon labels"
+msgid "Choose the color of the text used for desktop icon labels"
 msgstr "Velg fargen til teksten som brukes til skrivebordsikon-etiketter"
 
 #: ../data/pipanel.ui.h:16
@@ -184,11 +184,11 @@ msgid "Show the taskbar at the bottom of the screen"
 msgstr "Vis oppgavelinjen nederst på skjermen"
 
 #: ../data/pipanel.ui.h:39
-msgid "Choose the colour of the taskbar background"
+msgid "Choose the color of the taskbar background"
 msgstr "Velg fargen på oppgavelinjens bakgrunn"
 
 #: ../data/pipanel.ui.h:40
-msgid "Choose the colour of text used on the taskbar"
+msgid "Choose the color of text used on the taskbar"
 msgstr "Velg fargen på teksten som brukes på oppgavelinjen"
 
 #: ../data/pipanel.ui.h:41
@@ -216,19 +216,19 @@ msgid "Choose the font used for labels and menus"
 msgstr "Velg skrifttypen som brukes til etiketter og menyer"
 
 #: ../data/pipanel.ui.h:47
-msgid "Highlight Colour"
+msgid "Highlight Color"
 msgstr "Fremhevingsfarge"
 
 #: ../data/pipanel.ui.h:48
-msgid "Choose the colour used to highlight active elements"
+msgid "Choose the color used to highlight active elements"
 msgstr "Velg fargen som brukes til å fremheve aktive elementer"
 
 #: ../data/pipanel.ui.h:49
-msgid "Highlight Text Colour"
+msgid "Highlight Text Color"
 msgstr "Fremhevingstekstfarge"
 
 #: ../data/pipanel.ui.h:50
-msgid "Choose the colour used for text on active elements"
+msgid "Choose the color used for text on active elements"
 msgstr "Velg fargen som brukes til tekst på aktive elementer"
 
 #: ../data/pipanel.ui.h:51

--- a/po/sk.po
+++ b/po/sk.po
@@ -76,19 +76,19 @@ msgid "Choose image file to use as wallpaper"
 msgstr "Vyberte súbor s obrázkom, ktorý sa má použiť ako pozadie"
 
 #: ../data/pipanel.ui.h:12
-msgid "Colour"
+msgid "Color"
 msgstr "Farba"
 
 #: ../data/pipanel.ui.h:13
-msgid "Choose the colour of the desktop background"
+msgid "Choose the color of the desktop background"
 msgstr "Vyberte farbu pozadia plochy"
 
 #: ../data/pipanel.ui.h:14
-msgid "Text Colour"
+msgid "Text Color"
 msgstr "Farba textu"
 
 #: ../data/pipanel.ui.h:15
-msgid "Choose the colour of the text used for desktop icon labels"
+msgid "Choose the color of the text used for desktop icon labels"
 msgstr "Vyberte farbu textu použitého na popisy ikon"
 
 #: ../data/pipanel.ui.h:16
@@ -184,11 +184,11 @@ msgid "Show the taskbar at the bottom of the screen"
 msgstr "Zobraziť panel úloh v spodnej časti obrazovky"
 
 #: ../data/pipanel.ui.h:39
-msgid "Choose the colour of the taskbar background"
+msgid "Choose the color of the taskbar background"
 msgstr "Vybrať farbu pozadia panelu úloh"
 
 #: ../data/pipanel.ui.h:40
-msgid "Choose the colour of text used on the taskbar"
+msgid "Choose the color of text used on the taskbar"
 msgstr "Vybrať farbu textu použitého na paneli úloh"
 
 #: ../data/pipanel.ui.h:41
@@ -216,19 +216,19 @@ msgid "Choose the font used for labels and menus"
 msgstr "Vybrať písmo použité na popisy a v ponukách"
 
 #: ../data/pipanel.ui.h:47
-msgid "Highlight Colour"
+msgid "Highlight Color"
 msgstr "Farba zvýraznenia"
 
 #: ../data/pipanel.ui.h:48
-msgid "Choose the colour used to highlight active elements"
+msgid "Choose the color used to highlight active elements"
 msgstr "Vybrať farbu použitú na označenie aktívnych prvkov"
 
 #: ../data/pipanel.ui.h:49
-msgid "Highlight Text Colour"
+msgid "Highlight Text Color"
 msgstr "Farba zvýrazneného textu"
 
 #: ../data/pipanel.ui.h:50
-msgid "Choose the colour used for text on active elements"
+msgid "Choose the color used for text on active elements"
 msgstr "Vybrať farbu textu aktívnych prvkov"
 
 #: ../data/pipanel.ui.h:51

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -26,11 +26,11 @@ msgid "Defaults"
 msgstr "預設"
 
 #: ../data/pipanel.ui.h:3
-msgid "Colour"
+msgid "Color"
 msgstr "色彩"
 
 #: ../data/pipanel.ui.h:4
-msgid "Text Colour"
+msgid "Text Color"
 msgstr "文字色彩"
 
 #: ../data/pipanel.ui.h:5
@@ -106,11 +106,11 @@ msgid "Font"
 msgstr "字型"
 
 #: ../data/pipanel.ui.h:23
-msgid "Highlight Colour"
+msgid "Highlight Color"
 msgstr "突顯色彩"
 
 #: ../data/pipanel.ui.h:24
-msgid "Highlight Text Colour"
+msgid "Highlight Text Color"
 msgstr "突顯文字色彩"
 
 #: ../data/pipanel.ui.h:25

--- a/src/pipanel.c
+++ b/src/pipanel.c
@@ -64,12 +64,12 @@ typedef struct {
     const char *desktop_mode[2];
     const char *terminal_font;
     const char *desktop_folder;
-    GdkRGBA theme_colour;
-    GdkRGBA themetext_colour;
-    GdkRGBA desktop_colour[2];
-    GdkRGBA desktoptext_colour[2];
-    GdkRGBA bar_colour;
-    GdkRGBA bartext_colour;
+    GdkRGBA theme_color;
+    GdkRGBA themetext_color;
+    GdkRGBA desktop_color[2];
+    GdkRGBA desktoptext_color[2];
+    GdkRGBA bar_color;
+    GdkRGBA bartext_color;
     int icon_size;
     int barpos;
     int show_docs[2];
@@ -152,12 +152,12 @@ static void defaults_pcman (int desktop);
 static void defaults_pcman_g (void);
 static void create_defaults (void);
 static void on_menu_size_set (GtkComboBox* btn, gpointer ptr);
-static void on_theme_colour_set (GtkColorChooser* btn, gpointer ptr);
-static void on_themetext_colour_set (GtkColorChooser* btn, gpointer ptr);
-static void on_bar_colour_set (GtkColorChooser* btn, gpointer ptr);
-static void on_bartext_colour_set (GtkColorChooser* btn, gpointer ptr);
-static void on_desktop_colour_set (GtkColorChooser* btn, gpointer ptr);
-static void on_desktoptext_colour_set (GtkColorChooser* btn, gpointer ptr);
+static void on_theme_color_set (GtkColorChooser* btn, gpointer ptr);
+static void on_themetext_color_set (GtkColorChooser* btn, gpointer ptr);
+static void on_bar_color_set (GtkColorChooser* btn, gpointer ptr);
+static void on_bartext_color_set (GtkColorChooser* btn, gpointer ptr);
+static void on_desktop_color_set (GtkColorChooser* btn, gpointer ptr);
+static void on_desktoptext_color_set (GtkColorChooser* btn, gpointer ptr);
 static void on_desktop_picture_set (GtkFileChooser* btn, gpointer ptr);
 static void on_desktop_font_set (GtkFontChooser* btn, gpointer ptr);
 static void on_desktop_mode_set (GtkComboBox* btn, gpointer ptr);
@@ -641,10 +641,10 @@ static void load_lxsession_settings (void)
     {
         g_key_file_free (kf);
         g_free (user_config_file);
-        DEFAULT (bar_colour);
-        DEFAULT (bartext_colour);
-        DEFAULT (theme_colour);
-        DEFAULT (themetext_colour);
+        DEFAULT (bar_color);
+        DEFAULT (bartext_color);
+        DEFAULT (theme_color);
+        DEFAULT (themetext_color);
         DEFAULT (desktop_font);
         DEFAULT (tb_icon_size);
         DEFAULT (cursor_size);
@@ -668,33 +668,33 @@ static void load_lxsession_settings (void)
             cptr = strtok (NULL, ":\n");
             if (!strcmp (nptr, "bar_fg_color"))
             {
-                if (!gdk_rgba_parse (&cur_conf.bartext_colour, cptr))
-                    DEFAULT (bartext_colour);
+                if (!gdk_rgba_parse (&cur_conf.bartext_color, cptr))
+                    DEFAULT (bartext_color);
             }
             else if (!strcmp (nptr, "bar_bg_color"))
             {
-                if (!gdk_rgba_parse (&cur_conf.bar_colour, cptr))
-                    DEFAULT (bar_colour);
+                if (!gdk_rgba_parse (&cur_conf.bar_color, cptr))
+                    DEFAULT (bar_color);
             }
             else if (!strcmp (nptr, "selected_fg_color"))
             {
-                if (!gdk_rgba_parse (&cur_conf.themetext_colour, cptr))
-                    DEFAULT (themetext_colour);
+                if (!gdk_rgba_parse (&cur_conf.themetext_color, cptr))
+                    DEFAULT (themetext_color);
             }
             else if (!strcmp (nptr, "selected_bg_color"))
             {
-                if (!gdk_rgba_parse (&cur_conf.theme_colour, cptr))
-                    DEFAULT (theme_colour);
+                if (!gdk_rgba_parse (&cur_conf.theme_color, cptr))
+                    DEFAULT (theme_color);
             }
             nptr = strtok (NULL, ":\n");
         }
     }
     else
     {
-        DEFAULT (bar_colour);
-        DEFAULT (bartext_colour);
-        DEFAULT (theme_colour);
-        DEFAULT (themetext_colour);
+        DEFAULT (bar_color);
+        DEFAULT (bartext_color);
+        DEFAULT (theme_color);
+        DEFAULT (themetext_color);
     }
     g_free (ret);
 
@@ -736,20 +736,20 @@ static void load_pcman_settings (int desktop)
         ret = g_key_file_get_string (kf, "*", "desktop_bg", &err);
         if (err == NULL)
         {
-            if (!gdk_rgba_parse (&cur_conf.desktop_colour[desktop], ret))
-                DEFAULT (desktop_colour[desktop]);
+            if (!gdk_rgba_parse (&cur_conf.desktop_color[desktop], ret))
+                DEFAULT (desktop_color[desktop]);
         }
-        else DEFAULT (desktop_colour[desktop]);
+        else DEFAULT (desktop_color[desktop]);
         g_free (ret);
 
         err = NULL;
         ret = g_key_file_get_string (kf, "*", "desktop_fg", &err);
         if (err == NULL)
         {
-            if (!gdk_rgba_parse (&cur_conf.desktoptext_colour[desktop], ret))
-                DEFAULT (desktoptext_colour[desktop]);
+            if (!gdk_rgba_parse (&cur_conf.desktoptext_color[desktop], ret))
+                DEFAULT (desktoptext_color[desktop]);
         }
-        else DEFAULT (desktoptext_colour[desktop]);
+        else DEFAULT (desktoptext_color[desktop]);
         g_free (ret);
 
         err = NULL;
@@ -790,8 +790,8 @@ static void load_pcman_settings (int desktop)
     }
     else
     {
-        DEFAULT (desktop_colour[desktop]);
-        DEFAULT (desktoptext_colour[desktop]);
+        DEFAULT (desktop_color[desktop]);
+        DEFAULT (desktoptext_color[desktop]);
         DEFAULT (desktop_picture[desktop]);
         DEFAULT (desktop_mode[desktop]);
         DEFAULT (show_docs[desktop]);
@@ -990,10 +990,10 @@ static void save_gtk3_settings (void)
     vsystem ("if grep -q -s define-color %s ; then rm %s ; fi", user_config_file, user_config_file);
     g_free (user_config_file);
 
-    cstrb = rgba_to_gdk_color_string (&cur_conf.theme_colour);
-    cstrf = rgba_to_gdk_color_string (&cur_conf.themetext_colour);
-    cstrbb = rgba_to_gdk_color_string (&cur_conf.bar_colour);
-    cstrbf = rgba_to_gdk_color_string (&cur_conf.bartext_colour);
+    cstrb = rgba_to_gdk_color_string (&cur_conf.theme_color);
+    cstrf = rgba_to_gdk_color_string (&cur_conf.themetext_color);
+    cstrbb = rgba_to_gdk_color_string (&cur_conf.bar_color);
+    cstrbf = rgba_to_gdk_color_string (&cur_conf.bartext_color);
 
     // create a temp theme to switch to
     link1 = g_build_filename (g_get_user_data_dir (), "themes/tPiXflat", NULL);
@@ -1093,10 +1093,10 @@ static void save_lxsession_settings (void)
     g_key_file_set_string (kf, "GTK", "sNet/ThemeName", TEMP_THEME);
 
     // update changed values in the key file
-    ctheme = rgba_to_gdk_color_string (&cur_conf.theme_colour);
-    cthemet = rgba_to_gdk_color_string (&cur_conf.themetext_colour);
-    cbar = rgba_to_gdk_color_string (&cur_conf.bar_colour);
-    cbart = rgba_to_gdk_color_string (&cur_conf.bartext_colour);
+    ctheme = rgba_to_gdk_color_string (&cur_conf.theme_color);
+    cthemet = rgba_to_gdk_color_string (&cur_conf.themetext_color);
+    cbar = rgba_to_gdk_color_string (&cur_conf.bar_color);
+    cbart = rgba_to_gdk_color_string (&cur_conf.bartext_color);
 
     str = g_strdup_printf ("selected_bg_color:%s\nselected_fg_color:%s\nbar_bg_color:%s\nbar_fg_color:%s\n",
         ctheme, cthemet, cbar, cbart);
@@ -1188,10 +1188,10 @@ static void save_xsettings (void)
         vsystem ("cp /etc/xsettingsd/xsettingsd.conf %s", user_config_file);
     }
 
-    ctheme = rgba_to_gdk_color_string (&cur_conf.theme_colour);
-    cthemet = rgba_to_gdk_color_string (&cur_conf.themetext_colour);
-    cbar = rgba_to_gdk_color_string (&cur_conf.bar_colour);
-    cbart = rgba_to_gdk_color_string (&cur_conf.bartext_colour);
+    ctheme = rgba_to_gdk_color_string (&cur_conf.theme_color);
+    cthemet = rgba_to_gdk_color_string (&cur_conf.themetext_color);
+    cbar = rgba_to_gdk_color_string (&cur_conf.bar_color);
+    cbart = rgba_to_gdk_color_string (&cur_conf.bartext_color);
 
     str = g_strdup_printf ("selected_bg_color:%s\\\\nselected_fg_color:%s\\\\nbar_bg_color:%s\\\\nbar_fg_color:%s\\\\n",
         ctheme, cthemet, cbar, cbart);
@@ -1229,12 +1229,12 @@ static void save_pcman_settings (int desktop)
     kf = g_key_file_new ();
     g_key_file_load_from_file (kf, user_config_file, G_KEY_FILE_KEEP_COMMENTS | G_KEY_FILE_KEEP_TRANSLATIONS, NULL);
 
-    str = rgba_to_gdk_color_string (&cur_conf.desktop_colour[desktop]);
+    str = rgba_to_gdk_color_string (&cur_conf.desktop_color[desktop]);
     g_key_file_set_string (kf, "*", "desktop_bg", str);
     g_key_file_set_string (kf, "*", "desktop_shadow", str);
     g_free (str);
 
-    str = rgba_to_gdk_color_string (&cur_conf.desktoptext_colour[desktop]);
+    str = rgba_to_gdk_color_string (&cur_conf.desktoptext_color[desktop]);
     g_key_file_set_string (kf, "*", "desktop_fg", str);
     g_free (str);
 
@@ -1476,7 +1476,7 @@ static void save_obconf_settings (void)
         xmlNodeSetContent (cur_node, XC (buf));
     }
 
-    cptr = rgba_to_gdk_color_string (&cur_conf.theme_colour);
+    cptr = rgba_to_gdk_color_string (&cur_conf.theme_color);
     xpathObj = xmlXPathEvalExpression ((xmlChar *) "/*[local-name()='openbox_config']/*[local-name()='theme']/*[local-name()='titleColor']", xpathCtx);
     if (xmlXPathNodeSetIsEmpty (xpathObj->nodesetval))
     {
@@ -1492,7 +1492,7 @@ static void save_obconf_settings (void)
     }
     g_free (cptr);
 
-    cptr = rgba_to_gdk_color_string (&cur_conf.themetext_colour);
+    cptr = rgba_to_gdk_color_string (&cur_conf.themetext_color);
     xpathObj = xmlXPathEvalExpression ((xmlChar *) "/*[local-name()='openbox_config']/*[local-name()='theme']/*[local-name()='textColor']", xpathCtx);
     if (xmlXPathNodeSetIsEmpty (xpathObj->nodesetval))
     {
@@ -1895,9 +1895,9 @@ static void on_menu_size_set (GtkComboBox* btn, gpointer ptr)
     }
 }
 
-static void on_theme_colour_set (GtkColorChooser* btn, gpointer ptr)
+static void on_theme_color_set (GtkColorChooser* btn, gpointer ptr)
 {
-    gtk_color_chooser_get_rgba (btn, &cur_conf.theme_colour);
+    gtk_color_chooser_get_rgba (btn, &cur_conf.theme_color);
     save_lxsession_settings ();
     save_xsettings ();
     save_obconf_settings ();
@@ -1909,9 +1909,9 @@ static void on_theme_colour_set (GtkColorChooser* btn, gpointer ptr)
     reload_theme (FALSE);
 }
 
-static void on_themetext_colour_set (GtkColorChooser* btn, gpointer ptr)
+static void on_themetext_color_set (GtkColorChooser* btn, gpointer ptr)
 {
-    gtk_color_chooser_get_rgba (btn, &cur_conf.themetext_colour);
+    gtk_color_chooser_get_rgba (btn, &cur_conf.themetext_color);
     save_lxsession_settings ();
     save_xsettings ();
     save_obconf_settings ();
@@ -1923,9 +1923,9 @@ static void on_themetext_colour_set (GtkColorChooser* btn, gpointer ptr)
     reload_theme (FALSE);
 }
 
-static void on_bar_colour_set (GtkColorChooser* btn, gpointer ptr)
+static void on_bar_color_set (GtkColorChooser* btn, gpointer ptr)
 {
-    gtk_color_chooser_get_rgba (btn, &cur_conf.bar_colour);
+    gtk_color_chooser_get_rgba (btn, &cur_conf.bar_color);
     save_lxsession_settings ();
     save_xsettings ();
     save_gtk3_settings ();
@@ -1935,9 +1935,9 @@ static void on_bar_colour_set (GtkColorChooser* btn, gpointer ptr)
     reload_theme (FALSE);
 }
 
-static void on_bartext_colour_set (GtkColorChooser* btn, gpointer ptr)
+static void on_bartext_color_set (GtkColorChooser* btn, gpointer ptr)
 {
-    gtk_color_chooser_get_rgba (btn, &cur_conf.bartext_colour);
+    gtk_color_chooser_get_rgba (btn, &cur_conf.bartext_color);
     save_lxsession_settings ();
     save_xsettings ();
     save_gtk3_settings ();
@@ -1947,18 +1947,18 @@ static void on_bartext_colour_set (GtkColorChooser* btn, gpointer ptr)
     reload_theme (FALSE);
 }
 
-static void on_desktop_colour_set (GtkColorChooser* btn, gpointer ptr)
+static void on_desktop_color_set (GtkColorChooser* btn, gpointer ptr)
 {
     int desk = (int) ptr;
-    gtk_color_chooser_get_rgba (btn, &cur_conf.desktop_colour[desk]);
+    gtk_color_chooser_get_rgba (btn, &cur_conf.desktop_color[desk]);
     save_pcman_settings (desk);
     reload_pcmanfm ();
 }
 
-static void on_desktoptext_colour_set (GtkColorChooser* btn, gpointer ptr)
+static void on_desktoptext_color_set (GtkColorChooser* btn, gpointer ptr)
 {
     int desk = (int) ptr;
-    gtk_color_chooser_get_rgba (btn, &cur_conf.desktoptext_colour[desk]);
+    gtk_color_chooser_get_rgba (btn, &cur_conf.desktoptext_color[desk]);
     save_pcman_settings (desk);
     reload_pcmanfm ();
 }
@@ -2181,16 +2181,16 @@ static void set_controls (void)
             gtk_combo_box_set_active (GTK_COMBO_BOX (dmod[i]), 0);
             gtk_widget_set_sensitive (GTK_WIDGET (dpic[i]), FALSE);
         }
-        gtk_color_chooser_set_rgba (GTK_COLOR_CHOOSER (dcol[i]), &cur_conf.desktop_colour[i]);
-        gtk_color_chooser_set_rgba (GTK_COLOR_CHOOSER (dtcol[i]), &cur_conf.desktoptext_colour[i]);
+        gtk_color_chooser_set_rgba (GTK_COLOR_CHOOSER (dcol[i]), &cur_conf.desktop_color[i]);
+        gtk_color_chooser_set_rgba (GTK_COLOR_CHOOSER (dtcol[i]), &cur_conf.desktoptext_color[i]);
         gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (cb1[i]), cur_conf.show_docs[i]);
         gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (cb2[i]), cur_conf.show_trash[i]);
         gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (cb3[i]), cur_conf.show_mnts[i]);
     }
-    gtk_color_chooser_set_rgba (GTK_COLOR_CHOOSER (hcol), &cur_conf.theme_colour);
-    gtk_color_chooser_set_rgba (GTK_COLOR_CHOOSER (btcol), &cur_conf.bartext_colour);
-    gtk_color_chooser_set_rgba (GTK_COLOR_CHOOSER (bcol), &cur_conf.bar_colour);
-    gtk_color_chooser_set_rgba (GTK_COLOR_CHOOSER (htcol), &cur_conf.themetext_colour);
+    gtk_color_chooser_set_rgba (GTK_COLOR_CHOOSER (hcol), &cur_conf.theme_color);
+    gtk_color_chooser_set_rgba (GTK_COLOR_CHOOSER (btcol), &cur_conf.bartext_color);
+    gtk_color_chooser_set_rgba (GTK_COLOR_CHOOSER (bcol), &cur_conf.bar_color);
+    gtk_color_chooser_set_rgba (GTK_COLOR_CHOOSER (htcol), &cur_conf.themetext_color);
 
     if (cur_conf.icon_size <= 20) gtk_combo_box_set_active (GTK_COMBO_BOX (isz), 3);
     else if (cur_conf.icon_size <= 28) gtk_combo_box_set_active (GTK_COMBO_BOX (isz), 2);
@@ -2340,43 +2340,43 @@ static void defaults_lxsession ()
                 cptr = strtok (NULL, ":\n");
                 if (!strcmp (nptr, "bar_fg_color"))
                 {
-                    if (!gdk_rgba_parse (&def_med.bartext_colour, cptr))
-                        gdk_rgba_parse (&def_med.bartext_colour, GREY);
+                    if (!gdk_rgba_parse (&def_med.bartext_color, cptr))
+                        gdk_rgba_parse (&def_med.bartext_color, GREY);
                 }
                 else if (!strcmp (nptr, "bar_bg_color"))
                 {
-                    if (!gdk_rgba_parse (&def_med.bar_colour, cptr))
-                        gdk_rgba_parse (&def_med.bar_colour, GREY);
+                    if (!gdk_rgba_parse (&def_med.bar_color, cptr))
+                        gdk_rgba_parse (&def_med.bar_color, GREY);
                 }
                 else if (!strcmp (nptr, "selected_fg_color"))
                 {
-                    if (!gdk_rgba_parse (&def_med.themetext_colour, cptr))
-                        gdk_rgba_parse (&def_med.themetext_colour, GREY);
+                    if (!gdk_rgba_parse (&def_med.themetext_color, cptr))
+                        gdk_rgba_parse (&def_med.themetext_color, GREY);
                 }
                 else if (!strcmp (nptr, "selected_bg_color"))
                 {
-                    if (!gdk_rgba_parse (&def_med.theme_colour, cptr))
-                        gdk_rgba_parse (&def_med.theme_colour, GREY);
+                    if (!gdk_rgba_parse (&def_med.theme_color, cptr))
+                        gdk_rgba_parse (&def_med.theme_color, GREY);
                 }
                 nptr = strtok (NULL, ":\n");
             }
         }
         else
         {
-            gdk_rgba_parse (&def_med.theme_colour, GREY);
-            gdk_rgba_parse (&def_med.themetext_colour, GREY);
-            gdk_rgba_parse (&def_med.bar_colour, GREY);
-            gdk_rgba_parse (&def_med.bartext_colour, GREY);
+            gdk_rgba_parse (&def_med.theme_color, GREY);
+            gdk_rgba_parse (&def_med.themetext_color, GREY);
+            gdk_rgba_parse (&def_med.bar_color, GREY);
+            gdk_rgba_parse (&def_med.bartext_color, GREY);
         }
         g_free (ret);
     }
     else
     {
         def_med.desktop_font = "";
-        gdk_rgba_parse (&def_med.theme_colour, GREY);
-        gdk_rgba_parse (&def_med.themetext_colour, GREY);
-        gdk_rgba_parse (&def_med.bar_colour, GREY);
-        gdk_rgba_parse (&def_med.bartext_colour, GREY);
+        gdk_rgba_parse (&def_med.theme_color, GREY);
+        gdk_rgba_parse (&def_med.themetext_color, GREY);
+        gdk_rgba_parse (&def_med.bar_color, GREY);
+        gdk_rgba_parse (&def_med.bartext_color, GREY);
         def_med.cursor_size = 0;
     }
     g_key_file_free (kf);
@@ -2400,20 +2400,20 @@ static void defaults_pcman (int desktop)
         ret = g_key_file_get_string (kf, "*", "desktop_bg", &err);
         if (err == NULL)
         {
-            if (!gdk_rgba_parse (&def_med.desktop_colour[desktop], ret))
-                gdk_rgba_parse (&def_med.desktop_colour[desktop], GREY);
+            if (!gdk_rgba_parse (&def_med.desktop_color[desktop], ret))
+                gdk_rgba_parse (&def_med.desktop_color[desktop], GREY);
         }
-        else gdk_rgba_parse (&def_med.desktop_colour[desktop], GREY);
+        else gdk_rgba_parse (&def_med.desktop_color[desktop], GREY);
         g_free (ret);
 
         err = NULL;
         ret = g_key_file_get_string (kf, "*", "desktop_fg", &err);
         if (err == NULL)
         {
-            if (!gdk_rgba_parse (&def_med.desktoptext_colour[desktop], ret))
-                gdk_rgba_parse (&def_med.desktoptext_colour[desktop], GREY);
+            if (!gdk_rgba_parse (&def_med.desktoptext_color[desktop], ret))
+                gdk_rgba_parse (&def_med.desktoptext_color[desktop], GREY);
         }
-        else gdk_rgba_parse (&def_med.desktoptext_colour[desktop], GREY);
+        else gdk_rgba_parse (&def_med.desktoptext_color[desktop], GREY);
         g_free (ret);
 
         err = NULL;
@@ -2456,8 +2456,8 @@ static void defaults_pcman (int desktop)
     {
         def_med.desktop_picture[desktop] = "";
         def_med.desktop_mode[desktop] = "color";
-        gdk_rgba_parse (&def_med.desktop_colour[desktop], GREY);
-        gdk_rgba_parse (&def_med.desktoptext_colour[desktop], GREY);
+        gdk_rgba_parse (&def_med.desktop_color[desktop], GREY);
+        gdk_rgba_parse (&def_med.desktoptext_color[desktop], GREY);
         def_med.show_docs[desktop] = 0;
         def_med.show_trash[desktop] = 0;
         def_med.show_mnts[desktop] = 0;
@@ -2695,16 +2695,16 @@ static gboolean init_config (gpointer data)
     g_signal_connect (font, "font-set", G_CALLBACK (on_desktop_font_set), NULL);
 
     hcol = gtk_builder_get_object (builder, "colorbutton1");
-    g_signal_connect (hcol, "color-set", G_CALLBACK (on_theme_colour_set), NULL);
+    g_signal_connect (hcol, "color-set", G_CALLBACK (on_theme_color_set), NULL);
 
     bcol = gtk_builder_get_object (builder, "colorbutton3");
-    g_signal_connect (bcol, "color-set", G_CALLBACK (on_bar_colour_set), NULL);
+    g_signal_connect (bcol, "color-set", G_CALLBACK (on_bar_color_set), NULL);
 
     btcol = gtk_builder_get_object (builder, "colorbutton4");
-    g_signal_connect (btcol, "color-set", G_CALLBACK (on_bartext_colour_set), NULL);
+    g_signal_connect (btcol, "color-set", G_CALLBACK (on_bartext_color_set), NULL);
 
     htcol = gtk_builder_get_object (builder, "colorbutton5");
-    g_signal_connect (htcol, "color-set", G_CALLBACK (on_themetext_colour_set), NULL);
+    g_signal_connect (htcol, "color-set", G_CALLBACK (on_themetext_color_set), NULL);
 
     item = gtk_builder_get_object (builder, "defs_lg");
     g_signal_connect (item, "clicked", G_CALLBACK (on_set_defaults), 3);
@@ -2732,10 +2732,10 @@ static gboolean init_config (gpointer data)
     for (i = 0; i < 2; i++)
     {
         dcol[i] = gtk_builder_get_object (builder, i ? "colorbutton2_" : "colorbutton2");
-        g_signal_connect (dcol[i], "color-set", G_CALLBACK (on_desktop_colour_set), (void *) i);
+        g_signal_connect (dcol[i], "color-set", G_CALLBACK (on_desktop_color_set), (void *) i);
 
         dtcol[i] = gtk_builder_get_object (builder, i ? "colorbutton6_" : "colorbutton6");
-        g_signal_connect (dtcol[i], "color-set", G_CALLBACK (on_desktoptext_colour_set), (void *) i);
+        g_signal_connect (dtcol[i], "color-set", G_CALLBACK (on_desktoptext_color_set), (void *) i);
 
         dpic[i] = gtk_builder_get_object (builder, i ? "filechooserbutton1_" : "filechooserbutton1");
         g_signal_connect (dpic[i], "file-set", G_CALLBACK (on_desktop_picture_set), (void *) i);


### PR DESCRIPTION
* Add German translation, closes #17
* Use International English spelling for "color" except for `en_GB.po`